### PR TITLE
Proposal for adding local filepath support

### DIFF
--- a/task/precodesigning.ts
+++ b/task/precodesigning.ts
@@ -7,9 +7,18 @@ async function run(): Promise<void> {
     let secureFileHelper: sec.SecureFileDownloader = new sec.SecureFileDownloader();
     try {
         tl.setResourcePath(path.join(__dirname, "task.json"));
+        
+        let secureFilePath: string;
+        let secureFileLocation: string = tl.getInput("secureFileLocation", true);
+        if (secureFileLocation == "azure") {
+            secureFileId = tl.getInput("secureFileId", true);
+            secureFilePath = await secureFileHelper.downloadSecureFile(secureFileId);
+        }
+        else if (secureFileLocation == "filepath")
+            secureFilePath = tl.getInput("secureFileLocalPath", true);
+        else
+            throw "The configured secure file location is invalid."
 
-        secureFileId = tl.getInput("secureFileId", true);
-        let secureFilePath: string = await secureFileHelper.downloadSecureFile(secureFileId);
         tl.setTaskVariable("SECURE_FILE_PATH", secureFilePath);
     } catch (err) {
         tl.setResult(tl.TaskResult.Failed, err);

--- a/task/task.json
+++ b/task/task.json
@@ -36,6 +36,7 @@
       "type": "secureFile",
       "label": "Secure File",
       "defaultValue": "",
+      "required": false,
       "visibleRule": "secureFileLocation = azure",
       "helpMarkDown": "Select the certificate that was uploaded to `Secure Files` to be used to sign the given files."
     },
@@ -44,6 +45,7 @@
       "type": "string",
       "label": "Secure File Path",
       "defaultValue": "",
+      "required": false,
       "visibleRule": "secureFileLocation = filepath",
       "helpMarkDown": "Enter the filepath of the certificate to be used to sign the given files."
     },

--- a/task/task.json
+++ b/task/task.json
@@ -20,12 +20,32 @@
   "instanceNameFormat": "Code Signing $(filePath)",
   "inputs": [
     {
+      "name": "secureFileLocation",
+      "type": "radio",
+      "label": "Secure File Location",
+      "helpMarkDown": "Indicates where the secure file is located. Certificate can either be retrieved from the project's secure files library or a specific filesystem path on the build machine.",
+      "required": true,
+      "defaultValue": "azure",
+      "options": {
+        "azure": "Azure secure files library",
+        "filepath": "Local filepath"
+      }
+    },
+    {
       "name": "secureFileId",
       "type": "secureFile",
       "label": "Secure File",
       "defaultValue": "",
-      "required": true,
+      "visibleRule": "secureFileLocation = azure",
       "helpMarkDown": "Select the certificate that was uploaded to `Secure Files` to be used to sign the given files."
+    },
+    {
+      "name": "secureFileLocalPath",
+      "type": "string",
+      "label": "Secure File Path",
+      "defaultValue": "",
+      "visibleRule": "secureFileLocation = filepath",
+      "helpMarkDown": "Enter the filepath of the certificate to be used to sign the given files."
     },
     {
       "name": "signCertPassword",


### PR DESCRIPTION
As mentioned in issue #38, the code signing task is failing when adding a condition to the task. This seems to be caused by the pipeline's handling of secure file downloads, which prevents conditions from being applied successfully.

To create an alternative solution, these proposed changes would allow a user to manually configure the local filepath of the certificate that should be used for signing. This could allow a user to point to a cert store that already exists on the build machine, or to simply implement the [DownloadSecureFile](https://docs.microsoft.com/en-us/azure/devops/pipelines/library/secure-files) task separately.

Changes:

- _task.json_: Added the `secureFileLocation` and `secureFileLocalPath` options. The idea is that the user can select whether the task should look for the cert in the Azure secure files library or a local filepath, determined by the `secureFileLocation` property. For UI-based configuration, the `secureFileLocation` option is presented as a radio button with Azure as the default choice. The UI will also show/hide the `secureFileLocalPath` and `secureFileId` controls based on which location is selected. This change required removing the `"required": true` flag on the `secureFileId` field, since the web page will still trigger validation even if the control is hidden.
- _precodesigning.ts_: Using the added `secureFileLocation` input value, conditional logic is applied to determine how the `SECURE_FILE_PATH` task variable should be set. If the location was set to Azure, then the secure file will be downloaded using the same method as before. However, if the location was set to a specific filepath, then the task variable will be populated by the value configured in the `secureFileLocalPath` input. The rest of the task's logic can remain unchanged.